### PR TITLE
MAGENTO-1976: added exclude-filelist.txt file and modified rsync comm…

### DIFF
--- a/release/build_release_package.sh
+++ b/release/build_release_package.sh
@@ -18,7 +18,7 @@ unzip release/magento1702.zip -d release/magento
 rsync -av src/ release/magento
 rsync -av CHANGELOG.md release/magento/app/code/community/Shopgate/Framework/CHANGELOG.md
 mkdir release/magento/lib/Shopgate
-rsync -av vendor/shopgate/cart-integration-sdk/ release/magento/lib/Shopgate/cart-integration-sdk
+rsync -av --exclude-from './release/exclude-filelist.txt' vendor/shopgate/cart-integration-sdk/ release/magento/lib/Shopgate/cart-integration-sdk
 rsync -av release/magento_package.php release/magento/magento_package.php
 
 cd release/magento/

--- a/release/exclude-filelist.txt
+++ b/release/exclude-filelist.txt
@@ -1,0 +1,6 @@
+.git/
+.gitignore
+.travis.yml
+.php-cs.cache
+.php-cs.dist
+.travis.yml


### PR DESCRIPTION
…and of the build_release_package.sh script  used to move the cart-integration-sdk directory to use the exclude list

@andre-kraus 
Sorry to blindly assign this review to you. If you are not able to do the review please let me know and I will seek another reviewer.

Thanks
Aaron