### PR TITLE
MAGENTO-1983

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Firing the sales order place events when importing an order
 
 ## [2.9.65] - 2018-29-01
 ### Fixed

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authn.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authn.php
@@ -78,7 +78,9 @@ class Shopgate_Framework_Model_Payment_Cc_Authn
                     $this->getOrder()->getPayment()->setAmountAuthorized($this->getOrder()->getGrandTotal());
                     $this->getOrder()->getPayment()->setBaseAmountAuthorized($this->getOrder()->getBaseGrandTotal());
                     $this->getOrder()->getPayment()->setIsTransactionPending(true);
+                    Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                     $this->_createTransaction($newTransactionType);
+                    Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
 
                     if ($this->_transactionType == self::SHOPGATE_PAYMENT_STATUS_AUTH_CAPTURE) {
                         $this->getOrder()->getPayment()->setIsTransactionPending(false);
@@ -86,7 +88,9 @@ class Shopgate_Framework_Model_Payment_Cc_Authn
                     break;
                 case self::RESPONSE_CODE_HELD:
                     if ($this->_isOrderPendingReview()) {
+                        Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                         $this->_createTransaction($newTransactionType, array('is_transaction_fraud' => true));
+                        Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
                         $this->getOrder()->getPayment()->setIsTransactionPending(true)->setIsFraudDetected(true);
                     }
                     break;

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authncim.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authncim.php
@@ -89,7 +89,9 @@ class Shopgate_Framework_Model_Payment_Cc_Authncim extends Shopgate_Framework_Mo
                     $this->_order->getPayment()->setAmountAuthorized($this->_order->getGrandTotal());
                     $this->_order->getPayment()->setBaseAmountAuthorized($this->_order->getBaseGrandTotal());
                     $this->_order->getPayment()->setIsTransactionPending(true);
+                    Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                     $this->_createTransaction($newTransactionType);
+                    Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
 
                     if ($this->_transactionType == self::SHOPGATE_PAYMENT_STATUS_AUTH_CAPTURE) {
                         $this->_order->getPayment()->setIsTransactionPending(false);
@@ -97,7 +99,9 @@ class Shopgate_Framework_Model_Payment_Cc_Authncim extends Shopgate_Framework_Mo
                     break;
                 case self::RESPONSE_CODE_HELD:
                     if ($this->_isOrderPendingReview()) {
+                        Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                         $this->_createTransaction($newTransactionType, array('is_transaction_fraud' => true));
+                        Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
                         $this->_order->getPayment()->setIsTransactionPending(true)->setIsFraudDetected(true);
                     }
                     break;

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authncim.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Cc/Authncim.php
@@ -89,9 +89,7 @@ class Shopgate_Framework_Model_Payment_Cc_Authncim extends Shopgate_Framework_Mo
                     $this->_order->getPayment()->setAmountAuthorized($this->_order->getGrandTotal());
                     $this->_order->getPayment()->setBaseAmountAuthorized($this->_order->getBaseGrandTotal());
                     $this->_order->getPayment()->setIsTransactionPending(true);
-                    Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                     $this->_createTransaction($newTransactionType);
-                    Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
 
                     if ($this->_transactionType == self::SHOPGATE_PAYMENT_STATUS_AUTH_CAPTURE) {
                         $this->_order->getPayment()->setIsTransactionPending(false);
@@ -99,9 +97,7 @@ class Shopgate_Framework_Model_Payment_Cc_Authncim extends Shopgate_Framework_Mo
                     break;
                 case self::RESPONSE_CODE_HELD:
                     if ($this->_isOrderPendingReview()) {
-                        Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
                         $this->_createTransaction($newTransactionType, array('is_transaction_fraud' => true));
-                        Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
                         $this->_order->getPayment()->setIsTransactionPending(true)->setIsFraudDetected(true);
                     }
                     break;
@@ -142,7 +138,9 @@ class Shopgate_Framework_Model_Payment_Cc_Authncim extends Shopgate_Framework_Mo
         foreach ($additionalInformation as $key => $value) {
             $transaction->setAdditionalInformation($key, $value);
         }
+        Mage::dispatchEvent('sales_order_place_before', array('order' => $this->getOrder()));
         $transaction->save();
+        Mage::dispatchEvent('sales_order_place_after', array('order' => $this->getOrder()));
     }
 
     /**

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Pp/Wspp.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Pp/Wspp.php
@@ -102,7 +102,9 @@ class Shopgate_Framework_Model_Payment_Pp_Wspp
         $transaction->addCommitCallback(array($order, 'save'));
 
         try {
+            Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $order));
             $transaction->save();
+            Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $order));
             Mage::dispatchEvent(
                 'sales_model_service_quote_submit_success',
                 array(

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Ppal/Plus.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Ppal/Plus.php
@@ -68,7 +68,9 @@ class Shopgate_Framework_Model_Payment_Ppal_Plus
         $transaction->addCommitCallback(array($order, 'save'));
 
         try {
+            Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $order));
             $transaction->save();
+            Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $order));
             Mage::dispatchEvent(
                 'sales_model_service_quote_submit_success',
                 array(

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Express.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Express.php
@@ -84,7 +84,9 @@ class Shopgate_Framework_Model_Payment_Simple_Paypal_Express
         $transaction->addCommitCallback(array($order, 'save'));
 
         try {
+            Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $order));
             $transaction->save();
+            Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $order));
             Mage::dispatchEvent(
                 'sales_model_service_quote_submit_success',
                 array(

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
@@ -36,7 +36,10 @@ class Shopgate_Framework_Model_Payment_Simple_Paypal_Standard
         $magentoOrder = parent::manipulateOrderWithPaymentData($magentoOrder);
 
         $info        = $this->getShopgateOrder()->getPaymentInfos();
+
+        Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $magentoOrder));
         $transaction = $this->_createTransaction($magentoOrder);
+        Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $magentoOrder));
         $magentoOrder->getPayment()->importTransactionInfo($transaction);
         $magentoOrder->getPayment()->setLastTransId($info[self::TYPE_TRANS_ID]);
 

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
@@ -36,7 +36,6 @@ class Shopgate_Framework_Model_Payment_Simple_Paypal_Standard
         $magentoOrder = parent::manipulateOrderWithPaymentData($magentoOrder);
 
         $info        = $this->getShopgateOrder()->getPaymentInfos();
-
         $transaction = $this->_createTransaction($magentoOrder);
         $magentoOrder->getPayment()->importTransactionInfo($transaction);
         $magentoOrder->getPayment()->setLastTransId($info[self::TYPE_TRANS_ID]);

--- a/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
+++ b/src/app/code/community/Shopgate/Framework/Model/Payment/Simple/Paypal/Standard.php
@@ -37,9 +37,7 @@ class Shopgate_Framework_Model_Payment_Simple_Paypal_Standard
 
         $info        = $this->getShopgateOrder()->getPaymentInfos();
 
-        Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $magentoOrder));
         $transaction = $this->_createTransaction($magentoOrder);
-        Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $magentoOrder));
         $magentoOrder->getPayment()->importTransactionInfo($transaction);
         $magentoOrder->getPayment()->setLastTransId($info[self::TYPE_TRANS_ID]);
 
@@ -74,7 +72,11 @@ class Shopgate_Framework_Model_Payment_Simple_Paypal_Standard
             ShopgateLogger::getInstance()->log($x->getMessage());
         }
 
-        return $transaction->save();
+        Mage::dispatchEvent('sales_order_place_before', array(self::TYPE_ORDER => $magentoOrder));
+        $transaction->save();
+        Mage::dispatchEvent('sales_order_place_after', array(self::TYPE_ORDER => $magentoOrder));
+
+        return $transaction;
     }
 
     /**


### PR DESCRIPTION
firing sales_order_place_before and sales_order_place_after in payment methods, where we do not use the core submitAll() function