### PR TITLE
MAGENTO-2379: improved calculation of net and gross prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - Error message about a product being out of stock
 - Cron job for shipping synchronisation in case of many shipping notifications
+- Improved calculation of net/gross amount of products in cart validation 
 
 ## [2.9.70] - 2018-08-22
 ### Fixed

--- a/src/app/code/community/Shopgate/Framework/Helper/Sales.php
+++ b/src/app/code/community/Shopgate/Framework/Helper/Sales.php
@@ -200,15 +200,30 @@ class Shopgate_Framework_Helper_Sales extends Mage_Core_Helper_Abstract
         /** @var Mage_Sales_Model_Quote_Item $_item */
         foreach ($quote->getAllVisibleItems() as $_item) {
             $price            = $_item->getProduct()->getFinalPrice();
-            $priceIncludesTax = Mage::helper('tax')->priceIncludesTax($quote->getStore());
-            $percent          = $_item->getTaxPercent();
-            if ($priceIncludesTax) {
-                $priceInclTax = $price;
-                $priceExclTax = $price / (1 + ($percent / 100));
-            } else {
-                $priceInclTax = $price * (1 + ($percent / 100));
-                $priceExclTax = $price;
-            }
+            $customerTaxClass = $quote->getCustomer() !== null
+                ? $quote->getCustomer()->getTaxClassId()
+                : null;
+
+            $priceInclTax = Mage::helper('tax')->getPrice(
+                $_item->getProduct(),
+                $price,
+                true,
+                $quote->getShippingAddress(),
+                $quote->getBillingAddress(),
+                $customerTaxClass,
+                $quote->getStore()
+            );
+
+            $priceExclTax = Mage::helper('tax')->getPrice(
+                $_item->getProduct(),
+                $price,
+                false,
+                $quote->getShippingAddress(),
+                $quote->getBillingAddress(),
+                $customerTaxClass,
+                $quote->getStore()
+            );
+
             $items[] = $validator->validateStock($_item, $priceInclTax, $priceExclTax);
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

In case of taxation based on billing address and using a country for that billing address where no taxes are configured in magento, checkCart was always returning the gross amount which differs from magentos logic.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
